### PR TITLE
Blackduck: Automated PR: Update com.fasterxml.jackson.core:jackson-databind:2.9.8 to 2.19.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.8</version>
+			<version>2.19.2</version>
 		</dependency>
 
 		<!-- Test -->


### PR DESCRIPTION
## Vulnerabilities associated with com.fasterxml.jackson.core:jackson-databind:2.9.8
[CVE-2019-14540](https://nvd.nist.gov/vuln/detail/CVE-2019-14540) *(CRITICAL)*: A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to com.zaxxer.hikari.HikariConfig.

[CVE-2019-14892](https://nvd.nist.gov/vuln/detail/CVE-2019-14892) *(CRITICAL)*: A flaw was discovered in jackson-databind in versions before 2.9.10, 2.8.11.5 and 2.6.7.3, where it would permit polymorphic deserialization of a malicious object using commons-configuration 1 and 2 JNDI classes. An attacker could use this flaw to execute arbitrary code.

[CVE-2019-14893](https://nvd.nist.gov/vuln/detail/CVE-2019-14893) *(CRITICAL)*: A flaw was discovered in FasterXML jackson-databind in all versions before 2.9.10 and 2.10.0, where it would permit polymorphic deserialization of malicious objects using the xalan JNDI gadget when used in conjunction with polymorphic type handling methods such as `enableDefaultTyping()` or when @JsonTypeInfo is using `Id.CLASS` or `Id.MINIMAL_CLASS` or in any other way which ObjectMapper.readValue might instantiate objects from unsafe sources. An attacker could use this flaw to execute arbitrary code.

[CVE-2019-16335](https://nvd.nist.gov/vuln/detail/CVE-2019-16335) *(CRITICAL)*: A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to com.zaxxer.hikari.HikariDataSource. This is a different vulnerability than CVE-2019-14540.

[CVE-2019-16942](https://nvd.nist.gov/vuln/detail/CVE-2019-16942) *(CRITICAL)*: A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the commons-dbcp (1.4) jar in the classpath, and an attacker can find an RMI service endpoint to access, it is possible to make the service execute a malicious payload. This issue exists because of org.apache.commons.dbcp.datasources.SharedPoolDataSource and org.apache.commons.dbcp.datasources.PerUserPoolDataSource mishandling.

[CVE-2019-16943](https://nvd.nist.gov/vuln/detail/CVE-2019-16943) *(CRITICAL)*: A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the p6spy (3.8.6) jar in the classpath, and an attacker can find an RMI service endpoint to access, it is possible to make the service execute a malicious payload. This issue exists because of com.p6spy.engine.spy.P6DataSource mishandling.

[CVE-2019-17267](https://nvd.nist.gov/vuln/detail/CVE-2019-17267) *(CRITICAL)*: A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to net.sf.ehcache.hibernate.EhcacheJtaTransactionManagerLookup.

[CVE-2019-17531](https://nvd.nist.gov/vuln/detail/CVE-2019-17531) *(CRITICAL)*: A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the apache-log4j-extra (version 1.2.x) jar in the classpath, and an attacker can provide a JNDI service to access, it is possible to make the service execute a malicious payload.

[CVE-2019-20330](https://nvd.nist.gov/vuln/detail/CVE-2019-20330) *(CRITICAL)*: FasterXML jackson-databind 2.x before 2.9.10.2 lacks certain net.sf.ehcache blocking.

[CVE-2020-8840](https://nvd.nist.gov/vuln/detail/CVE-2020-8840) *(CRITICAL)*: FasterXML jackson-databind 2.0.0 through 2.9.10.2 lacks certain xbean-reflect/JNDI blocking, as demonstrated by org.apache.xbean.propertyeditor.JndiConverter.

[CVE-2020-9546](https://nvd.nist.gov/vuln/detail/CVE-2020-9546) *(CRITICAL)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.hadoop.shaded.com.zaxxer.hikari.HikariConfig (aka shaded hikari-config).

[CVE-2020-9548](https://nvd.nist.gov/vuln/detail/CVE-2020-9548) *(CRITICAL)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to br.com.anteros.dbcp.AnterosDBCPConfig (aka anteros-core).

[CVE-2020-9547](https://nvd.nist.gov/vuln/detail/CVE-2020-9547) *(CRITICAL)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to com.ibatis.sqlmap.engine.transaction.jta.JtaTransactionConfig (aka ibatis-sqlmap).

[CVE-2020-14060](https://nvd.nist.gov/vuln/detail/CVE-2020-14060) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to oadd.org.apache.xalan.lib.sql.JNDIConnectionPool (aka apache/drill).

[CVE-2020-35491](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.SharedPoolDataSource.

[CVE-2020-10672](https://nvd.nist.gov/vuln/detail/CVE-2020-10672) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.aries.transaction.jms.internal.XaPooledConnectionFactory (aka aries.transaction.jms).

[CVE-2020-10673](https://nvd.nist.gov/vuln/detail/CVE-2020-10673) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to com.caucho.config.types.ResourceRef (aka caucho-quercus).

[CVE-2020-10968](https://nvd.nist.gov/vuln/detail/CVE-2020-10968) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.aoju.bus.proxy.provider.remoting.RmiProvider (aka bus-proxy).

[CVE-2020-10969](https://nvd.nist.gov/vuln/detail/CVE-2020-10969) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to javax.swing.JEditorPane.

[CVE-2020-11111](https://nvd.nist.gov/vuln/detail/CVE-2020-11111) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.activemq.* (aka activemq-jms, activemq-core, activemq-pool, and activemq-pool-jms).

[CVE-2020-11112](https://nvd.nist.gov/vuln/detail/CVE-2020-11112) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.proxy.provider.remoting.RmiProvider (aka apache/commons-proxy).

[CVE-2020-11113](https://nvd.nist.gov/vuln/detail/CVE-2020-11113) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.openjpa.ee.WASRegistryManagedRuntime (aka openjpa).

[CVE-2020-11619](https://nvd.nist.gov/vuln/detail/CVE-2020-11619) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.springframework.aop.config.MethodLocatingFactoryBean (aka spring-aop).

[CVE-2020-11620](https://nvd.nist.gov/vuln/detail/CVE-2020-11620) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.jelly.impl.Embedded (aka commons-jelly).

[CVE-2019-14439](https://nvd.nist.gov/vuln/detail/CVE-2019-14439) *(HIGH)*: A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9.2. This occurs when Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the logback jar in the classpath.

[CVE-2020-14061](https://nvd.nist.gov/vuln/detail/CVE-2020-14061) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to oracle.jms.AQjmsQueueConnectionFactory, oracle.jms.AQjmsXATopicConnectionFactory, oracle.jms.AQjmsTopicConnectionFactory, oracle.jms.AQjmsXAQueueConnectionFactory, and oracle.jms.AQjmsXAConnectionFactory (aka weblogic/oracle-aqjms).

[CVE-2020-14062](https://nvd.nist.gov/vuln/detail/CVE-2020-14062) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool (aka xalan2).

[CVE-2020-14195](https://nvd.nist.gov/vuln/detail/CVE-2020-14195) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to org.jsecurity.realm.jndi.JndiRealmFactory (aka org.jsecurity).

[CVE-2020-24616](https://nvd.nist.gov/vuln/detail/CVE-2020-24616) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.6 mishandles the interaction between serialization gadgets and typing, related to br.com.anteros.dbcp.AnterosDBCPDataSource (aka Anteros-DBCP).

[CVE-2020-24750](https://nvd.nist.gov/vuln/detail/CVE-2020-24750) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.6 mishandles the interaction between serialization gadgets and typing, related to com.pastdev.httpcomponents.configuration.JndiConfiguration.

[CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649) *(HIGH)*: A flaw was found in FasterXML Jackson Databind, where it did not have entity expansion secured properly. This flaw allows vulnerability to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.

[CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.PerUserPoolDataSource.

[CVE-2020-10650](https://nvd.nist.gov/vuln/detail/CVE-2020-10650) *(HIGH)*: A deserialization flaw was discovered in jackson-databind through 2.9.10.4. It could allow an unauthenticated user to perform code execution via ignite-jta or quartz-core: org.apache.ignite.cache.jta.jndi.CacheJndiTmLookup, org.apache.ignite.cache.jta.jndi.CacheJndiTmFactory, and org.quartz.utils.JNDIConnectionProvider.

[CVE-2020-35728](https://nvd.nist.gov/vuln/detail/CVE-2020-35728) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to com.oracle.wls.shaded.org.apache.xalan.lib.sql.JNDIConnectionPool (aka embedded Xalan in org.glassfish.web/javax.servlet.jsp.jstl).

[CVE-2020-36179](https://nvd.nist.gov/vuln/detail/CVE-2020-36179) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS.

[CVE-2020-36180](https://nvd.nist.gov/vuln/detail/CVE-2020-36180) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS.

[CVE-2020-36181](https://nvd.nist.gov/vuln/detail/CVE-2020-36181) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS.

[CVE-2020-36182](https://nvd.nist.gov/vuln/detail/CVE-2020-36182) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS.

[CVE-2020-36183](https://nvd.nist.gov/vuln/detail/CVE-2020-36183) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool.

[CVE-2020-36184](https://nvd.nist.gov/vuln/detail/CVE-2020-36184) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource.

[CVE-2020-36185](https://nvd.nist.gov/vuln/detail/CVE-2020-36185) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource.

[CVE-2020-36186](https://nvd.nist.gov/vuln/detail/CVE-2020-36186) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource.

[CVE-2020-36187](https://nvd.nist.gov/vuln/detail/CVE-2020-36187) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource.

[CVE-2020-36188](https://nvd.nist.gov/vuln/detail/CVE-2020-36188) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource.

[CVE-2019-12086](https://nvd.nist.gov/vuln/detail/CVE-2019-12086) *(HIGH)*: A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. This occurs because of missing com.mysql.cj.jdbc.admin.MiniAdmin validation.

[BDSA-2019-2355](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-2355) *(HIGH)*: FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to insufficient blacklisting of  dangerous classes when used along with Ehcache. Ehcache is an open source, standards-based cache that boosts performance. An attacker could leverage a dangerous transaction manager class to deserialize untrusted input and execute arbitrary code on the underlying host.

[CVE-2020-36189](https://nvd.nist.gov/vuln/detail/CVE-2020-36189) *(HIGH)*: FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource.

[CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) *(HIGH)*: jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.

[CVE-2021-20190](https://nvd.nist.gov/vuln/detail/CVE-2021-20190) *(HIGH)*: A flaw was found in jackson-databind before 2.9.10.7. FasterXML mishandles the interaction between serialization gadgets and typing. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.

[CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003) *(HIGH)*: In FasterXML jackson-databind before versions 2.13.4.1 and 2.12.17.1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled.

[CVE-2022-42004](https://nvd.nist.gov/vuln/detail/CVE-2022-42004) *(HIGH)*: In FasterXML jackson-databind before 2.13.4, resource exhaustion can occur because of a lack of a check in BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays. An application is vulnerable only with certain customized choices for deserialization.

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone//api/projects/72b4e4c9-ff49-40d7-9fa8-52788546cfbd/versions/4737bb1a-1607-4967-ad3f-e3adb7ae3d0a/vulnerability-bom?selectedItem=a31895d2-3d1d-4a57-934b-a0ae0c344bc3)