### PR TITLE
Blackduck: Automated PR: Update org.springframework:spring-jdbc:5.3.23 to 5.3.39-wso2v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<url>http://maven.apache.org</url>
 	<properties>
 		<java-version>17</java-version> <!-- JDK 17 사용 -->
-		<org.springframework-version>5.3.23</org.springframework-version>
+		<org.springframework-version>5.3.39-wso2v4</org.springframework-version>
 		<org.aspectj-version>1.9.7</org.aspectj-version>
 		<org.slf4j-version>1.7.36</org.slf4j-version>
 		<org.springsecurity-version>5.8.3</org.springsecurity-version>


### PR DESCRIPTION
## Vulnerabilities associated with org.springframework:spring-jdbc:5.3.23
[CVE-2016-1000027](https://nvd.nist.gov/vuln/detail/CVE-2016-1000027) *(CRITICAL)*: Pivotal Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required. NOTE: the vendor's position is that untrusted data is not an intended use case. The product's behavior will not be changed because some users rely on deserialization of trusted data.

[CVE-2023-20860](https://nvd.nist.gov/vuln/detail/CVE-2023-20860) *(HIGH)*: Spring Framework running version 6.0.0 - 6.0.6 or 5.3.0 - 5.3.25 using "**" as a pattern in Spring Security configuration with the mvcRequestMatcher creates a mismatch in pattern matching between Spring Security and Spring MVC, and the potential for a security bypass.

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone//api/projects/72b4e4c9-ff49-40d7-9fa8-52788546cfbd/versions/4737bb1a-1607-4967-ad3f-e3adb7ae3d0a/vulnerability-bom?selectedItem=7ca0a95a-01db-4c0f-a501-bcb59804c7c9)