### PR TITLE
Blackduck: Automated PR: Update com.google.code.gson:gson:2.8.7 to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.7</version>
+			<version>2.13.1</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
## Vulnerabilities associated with com.google.code.gson:gson:2.8.7
[CVE-2022-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647) *(HIGH)*: The package com.google.code.gson:gson before 2.8.9 are vulnerable to Deserialization of Untrusted Data via the writeReplace() method in internal classes, which may lead to DoS attacks.

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone//api/projects/72b4e4c9-ff49-40d7-9fa8-52788546cfbd/versions/4737bb1a-1607-4967-ad3f-e3adb7ae3d0a/vulnerability-bom?selectedItem=8a923312-f724-491e-9b4e-b30882894159)