### PR TITLE
Blackduck: Automated PR: Update org.hibernate.validator:hibernate-validator:6.0.13.Final to 6.2.5.Final-redhat-00001

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.13.Final</version>
+			<version>6.2.5.Final-redhat-00001</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>


### PR DESCRIPTION
## Vulnerabilities associated with org.hibernate.validator:hibernate-validator:6.0.13.Final
[BDSA-2020-4908](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-4908) *(HIGH)*: Hibernate Validator interpolates data in constraint violation messages as Expression Language. If attacker controlled data is part of a constraint violation message, Java code may be executed or sensitive data may be exfiltrated.

**Note**: The risks of this feature were properly documented, however the default behavior was deemed unsafe in practice. For this reason, in December of 2020, the developers removed the interpolation of custom constraint violation message data as Expression Language by default. They implemented a mechanism to more safely use Expression Language in the messages, which is documented [here](https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#section-hibernateconstraintvalidatorcontext).

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone//api/projects/72b4e4c9-ff49-40d7-9fa8-52788546cfbd/versions/4737bb1a-1607-4967-ad3f-e3adb7ae3d0a/vulnerability-bom?selectedItem=f6420ff1-ca85-4dcb-a51a-3562b5476051)