### PR TITLE
Blackduck: Automated PR: Update org.apache.struts:struts2-core:2.3.31 to 2.5.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
 			-->
 			<groupId>org.apache.struts</groupId>
 			<artifactId>struts2-core</artifactId>
-			<version>2.3.31</version>
+			<version>2.5.33</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
## Vulnerabilities associated with org.apache.struts:struts2-core:2.3.31
[CVE-2019-0230](https://nvd.nist.gov/vuln/detail/CVE-2019-0230) *(CRITICAL)*: Apache Struts 2.0.0 to 2.5.20 forced double OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution.

[CVE-2023-50164](https://nvd.nist.gov/vuln/detail/CVE-2023-50164) *(CRITICAL)*: An attacker can manipulate file upload params to enable paths traversal and under some circumstances this can lead to uploading a malicious file which can be used to perform Remote Code Execution.
Users are recommended to upgrade to versions Struts 2.5.33 or Struts 6.3.0.2 or greater to fix this issue.

[CVE-2021-31805](https://nvd.nist.gov/vuln/detail/CVE-2021-31805) *(CRITICAL)*: The fix issued for CVE-2020-17530 was incomplete. So from Apache Struts 2.0.0 to 2.5.29, still some of the tag’s attributes could perform a double evaluation if a developer applied forced OGNL evaluation by using the %{...} syntax. Using forced OGNL evaluation on untrusted user input can lead to a Remote Code Execution and security degradation.

[CVE-2017-12611](https://nvd.nist.gov/vuln/detail/CVE-2017-12611) *(CRITICAL)*: In Apache Struts 2.0.0 through 2.3.33 and 2.5 through 2.5.10.1, using an unintentional expression in a Freemarker tag instead of string literals can lead to a RCE attack.

[CVE-2017-5638](https://nvd.nist.gov/vuln/detail/CVE-2017-5638) *(CRITICAL)*: The Jakarta Multipart parser in Apache Struts 2 2.3.x before 2.3.32 and 2.5.x before 2.5.10.1 has incorrect exception handling and error-message generation during file-upload attempts, which allows remote attackers to execute arbitrary commands via a crafted Content-Type, Content-Disposition, or Content-Length HTTP header, as exploited in the wild in March 2017 with a Content-Type header containing a #cmd= string.

[BDSA-2024-9577](https://openhub.net/vulnerabilities/bdsa/BDSA-2024-9577) *(CRITICAL)*: A flawed logic issue has been identified in Apache Struts' file upload functionality. An attacker could exploit this by manipulating file upload parameters to enable paths traversal, and under specific circumstances could enable the uploading of malicious files which could be used to perform Remote Code Execution.

**Note:**  Per the Vendor, only applications using `FileUploadInterceptor` are affected.

[CVE-2017-9791](https://nvd.nist.gov/vuln/detail/CVE-2017-9791) *(CRITICAL)*: The Struts 1 plugin in Apache Struts 2.1.x and 2.3.x might allow remote code execution via a malicious field value passed in a raw message to the ActionMessage.

[CVE-2020-17530](https://nvd.nist.gov/vuln/detail/CVE-2020-17530) *(CRITICAL)*: Forced OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution. Affected software : Apache Struts 2.0.0 - Struts 2.5.25.

[CVE-2017-9787](https://nvd.nist.gov/vuln/detail/CVE-2017-9787) *(HIGH)*: When using a Spring AOP functionality to secure Struts actions it is possible to perform a DoS attack. Solution is to upgrade to Apache Struts version 2.5.12 or 2.3.33.

[CVE-2012-1592](https://nvd.nist.gov/vuln/detail/CVE-2012-1592) *(HIGH)*: A local code execution issue exists in Apache Struts2 when processing malformed XSLT files, which could let a malicious user upload and execute arbitrary files.

[CVE-2018-1327](https://nvd.nist.gov/vuln/detail/CVE-2018-1327) *(HIGH)*: The Apache Struts REST Plugin is using XStream library which is vulnerable and allow perform a DoS attack when using a malicious request with specially crafted XML payload. Upgrade to the Apache Struts version 2.5.16 and switch to an optional Jackson XML handler as described here http://struts.apache.org/plugins/rest/#custom-contenttypehandlers. Another option is to implement a custom XML handler based on the Jackson XML handler from the Apache Struts 2.5.16.

[CVE-2018-11776](https://nvd.nist.gov/vuln/detail/CVE-2018-11776) *(HIGH)*: Apache Struts versions 2.3 to 2.3.34 and 2.5 to 2.5.16 suffer from possible Remote Code Execution when alwaysSelectFullNamespace is true (either by user or a plugin like Convention Plugin) and then: results are used with no namespace and in same time, its upper package have no or wildcard namespace and similar to results, same possibility when using url tag which doesn't have value and action set and in same time, its upper package have no or wildcard namespace.

[BDSA-2016-1560](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1560) *(HIGH)*: Apache Struts2 is vulnerable to cross-site scripting when using versions of the Java Runtime Environment (JRE) with a broken implementation of `URLDecoder`.  This could allow an attacker to steal tokens, session cookies, credentials or other sensitive information.

[CVE-2019-0233](https://nvd.nist.gov/vuln/detail/CVE-2019-0233) *(HIGH)*: An access permission override in Apache Struts 2.0.0 to 2.5.20 may cause a Denial of Service when performing a file upload.

[CVE-2017-9793](https://nvd.nist.gov/vuln/detail/CVE-2017-9793) *(HIGH)*: The REST Plugin in Apache Struts 2.1.x, 2.3.7 through 2.3.33 and 2.5 through 2.5.12 is using an outdated XStream library which is vulnerable and allow perform a DoS attack using malicious request with specially crafted XML payload.

[CVE-2020-26258](https://nvd.nist.gov/vuln/detail/CVE-2020-26258) *(HIGH)*: XStream is a Java library to serialize objects to XML and back again. In XStream before version 1.4.15, a Server-Side Forgery Request vulnerability can be activated when unmarshalling. The vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream. If you rely on XStream's default blacklist of the Security Framework, you will have to use at least version 1.4.15. The reported vulnerability does not exist if running Java 15 or higher. No user is affected who followed the recommendation to setup XStream's Security Framework with a whitelist! Anyone relying on XStream's default blacklist can immediately switch to a whilelist for the allowed types to avoid the vulnerability. Users of XStream 1.4.14 or below who still want to use XStream default blacklist can use a workaround described in more detailed in the referenced advisories.

[CVE-2017-9804](https://nvd.nist.gov/vuln/detail/CVE-2017-9804) *(HIGH)*: In Apache Struts 2.3.7 through 2.3.33 and 2.5 through 2.5.12, if an application allows entering a URL in a form field and built-in URLValidator is used, it is possible to prepare a special URL which will be used to overload server process when performing validation of the URL.  NOTE: this vulnerability exists because of an incomplete fix for S2-047 / CVE-2017-7672.

[CVE-2023-34396](https://nvd.nist.gov/vuln/detail/CVE-2023-34396) *(HIGH)*: Allocation of Resources Without Limits or Throttling vulnerability in Apache Software Foundation Apache Struts.This issue affects Apache Struts: through 2.5.30, through 6.1.2.

Upgrade to Struts 2.5.31 or 6.1.2.1 or greater

[CVE-2017-9805](https://nvd.nist.gov/vuln/detail/CVE-2017-9805) *(HIGH)*: The REST Plugin in Apache Struts 2.1.1 through 2.3.x before 2.3.34 and 2.5.x before 2.5.13 uses an XStreamHandler with an instance of XStream for deserialization without any type filtering, which can lead to Remote Code Execution when deserializing XML payloads.

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone//api/projects/72b4e4c9-ff49-40d7-9fa8-52788546cfbd/versions/4737bb1a-1607-4967-ad3f-e3adb7ae3d0a/vulnerability-bom?selectedItem=a4fbc72d-556f-4baa-94e1-a79423addf62)