### PR TITLE
Blackduck: Automated PR: Update commons-collections:commons-collections:3.2.1 to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
 			-->
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
## Vulnerabilities associated with commons-collections:commons-collections:3.2.1
[BDSA-2015-0753](https://openhub.net/vulnerabilities/bdsa/BDSA-2015-0753) *(CRITICAL)*: The apache commons collection (ACC) library, when utilized in an application that deserializes untrusted user input, is vulnerable to a remote attacker executing arbitrary code.

[CVE-2015-7501](https://nvd.nist.gov/vuln/detail/CVE-2015-7501) *(CRITICAL)*: Red Hat JBoss A-MQ 6.x; BPM Suite (BPMS) 6.x; BRMS 6.x and 5.x; Data Grid (JDG) 6.x; Data Virtualization (JDV) 6.x and 5.x; Enterprise Application Platform 6.x, 5.x, and 4.3.x; Fuse 6.x; Fuse Service Works (FSW) 6.x; Operations Network (JBoss ON) 3.x; Portal 6.x; SOA Platform (SOA-P) 5.x; Web Server (JWS) 3.x; Red Hat OpenShift/xPAAS 3.x; and Red Hat Subscription Asset Manager 1.3 allow remote attackers to execute arbitrary commands via a crafted serialized Java object, related to the Apache Commons Collections (ACC) library.

[BDSA-2015-0766](https://openhub.net/vulnerabilities/bdsa/BDSA-2015-0766) *(HIGH)*: Apache Commons Collection is vulnerable to remote code execution (RCE) due to the unsafe handling of in-memory data structures. A remote attacker could execute arbitrary code on the underlying system by submitting crafted data packets to a vulnerable server.

[BDSA-2017-2285](https://openhub.net/vulnerabilities/bdsa/BDSA-2017-2285) *(HIGH)*: Apache Common Collections and Apache Synapse contain a vulnerability that allows for remote code execution (RCE) via crafted specialized objects. Failed attempts will cause a denial of service (DoS) attack.

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone//api/projects/72b4e4c9-ff49-40d7-9fa8-52788546cfbd/versions/4737bb1a-1607-4967-ad3f-e3adb7ae3d0a/vulnerability-bom?selectedItem=594af4e1-6cb7-4661-af5d-5478deeeb824)