### PR TITLE
Blackduck: Automated PR: Update org.apache.logging.log4j:log4j-core:2.14.1 to 2.25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
 			<!-- 공급망 보안 테스트 용 CVE-2021-44228 (Log4Shell) 취약점이 있는 버전 -->
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.14.1</version>
+			<version>2.25.1</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
## Vulnerabilities associated with org.apache.logging.log4j:log4j-core:2.14.1
[CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) *(CRITICAL)*: Apache Log4j2 2.0-beta9 through 2.15.0 (excluding security releases 2.12.2, 2.12.3, and 2.3.1) JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. From version 2.16.0 (along with 2.12.2, 2.12.3, and 2.3.1), this functionality has been completely removed. Note that this vulnerability is specific to log4j-core and does not affect log4net, log4cxx, or other Apache Logging Services projects.

[CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046) *(CRITICAL)*: It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allows attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in an information leak and remote code execution in some environments and local code execution in all environments. Log4j 2.16.0 (Java 8) and 2.12.2 (Java 7) fix this issue by removing support for message lookup patterns and disabling JNDI functionality by default.

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone//api/projects/72b4e4c9-ff49-40d7-9fa8-52788546cfbd/versions/4737bb1a-1607-4967-ad3f-e3adb7ae3d0a/vulnerability-bom?selectedItem=b14c1975-c1df-4a15-b4df-beb702cb3fb1)