### PR TITLE
Blackduck: Automated PR: Update org.apache.commons:commons-text:1.9 to 1.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
 			-->
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.9</version>
+			<version>1.14.0</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
## Vulnerabilities associated with org.apache.commons:commons-text:1.9
[CVE-2022-42889](https://nvd.nist.gov/vuln/detail/CVE-2022-42889) *(CRITICAL)*: Apache Commons Text performs variable interpolation, allowing properties to be dynamically evaluated and expanded. The standard format for interpolation is "${prefix:name}", where "prefix" is used to locate an instance of org.apache.commons.text.lookup.StringLookup that performs the interpolation. Starting with version 1.5 and continuing through 1.9, the set of default Lookup instances included interpolators that could result in arbitrary code execution or contact with remote servers. These lookups are: - "script" - execute expressions using the JVM script execution engine (javax.script) - "dns" - resolve dns records - "url" - load values from urls, including from remote servers Applications using the interpolation defaults in the affected versions may be vulnerable to remote code execution or unintentional contact with remote servers if untrusted configuration values are used. Users are recommended to upgrade to Apache Commons Text 1.10.0, which disables the problematic interpolators by default.

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone//api/projects/72b4e4c9-ff49-40d7-9fa8-52788546cfbd/versions/4737bb1a-1607-4967-ad3f-e3adb7ae3d0a/vulnerability-bom?selectedItem=18fbd399-fd08-4434-911e-4663b72ea189)